### PR TITLE
Don't need channel_id in activity body, and causes mass-assignment error in kandan

### DIFF
--- a/node_modules/hubot-kandan-heroku/node_modules/hubot-kandan/src/kandan.coffee
+++ b/node_modules/hubot-kandan-heroku/node_modules/hubot-kandan/src/kandan.coffee
@@ -90,7 +90,7 @@ class KandanStreaming extends EventEmitter
     @
 
   message: (message, channelId, callback) ->
-    body = {"content":message, "channel_id":channelId, "activity": {"content":message, "channel_id":channelId, "action":"message"}}
+    body = {"content":message, "channel_id":channelId, "activity": {"content":message, "action":"message"}}
     @post "/channels/#{ channelId }/activities", body, callback
 
   Channels: (callback) ->


### PR DESCRIPTION
Our Hubot was broken after we updated kandan. The kanan activities controller now scopes activities automatically to the channel id directly from the channel_id parameter. So the nested activity[:channel_id] parameter is no longer needed, and actually causes a mass-assignment error, causing hubot's post to fail.
